### PR TITLE
Switch the last of the nteract org to `uuid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ username, and then create and send a shutdown request:
 channels = ...connected using an enchannel backend...
 
 // Created once with the channels
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const session = uuid.v4();
 const username = process.env.LOGNAME || process.env.USER ||
   process.env.LNAME || process.env.USERNAME;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 
 /**
  * Filter for finding out if message is a child of parentMessage

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/nteract/enchannel#readme",
   "dependencies": {
-    "node-uuid": "^1.4.7"
+    "uuid": "^2.0.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
This is the last repo in the nteract org to use `node-uuid`.

This repo/package isn't used anywhere else _yet_, though I think it should end up in `enchannel-messaging` or `enchannel-helpers` instead of the base namespace.
